### PR TITLE
Add GitHub CLI installation hook to session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun x gh-setup-hooks",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Configure a Claude Code hook that runs `bun x gh-setup-hooks` when a new session starts, ensuring the GitHub CLI is available.